### PR TITLE
Add optional spawner abuse prevention

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,18 @@
 buildscript {
     repositories {
-        jcenter()
         maven {
-            name = "forge"
-            url = "https://files.minecraftforge.net/maven"
+            url = 'https://maven.minecraftforge.net/'
         }
+        mavenCentral()
     }
     dependencies {
-        classpath "net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT"
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
     }
 }
 
-apply plugin: "net.minecraftforge.gradle.forge"
+apply plugin: 'net.minecraftforge.gradle'
+
+
 
 version = modVersion
 group = modGroup
@@ -19,17 +20,34 @@ archivesBaseName = modBaseName
 
 sourceCompatibility = targetCompatibility = '1.8'
 
-minecraft {
-    version = project.forgeVersion
-    runDir = "run"
 
-    // the mappings can be changed at any time, and must be in the following format.
-    // snapshot_YYYYMMDD   snapshot are built nightly.
-    // stable_#            stables are built at the discretion of the MCP team.
-    // Use non-default mappings at your own risk. they may not always work.
-    // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = project.mcpVersion
-    replace "@VERSION@", project.version
+minecraft {
+    mappings channel: mappings_channel, version: mappings_version
+
+    runs {
+        client {
+            args "--username=InDev"
+
+            jvmArg "-Dmixin.hotSwap=true"
+            jvmArg "-Dmixin.checks.interfaces=true"
+
+            workingDirectory project.file('run')
+
+            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            property 'forge.logging.console.level', 'debug'
+        }
+
+        server {
+
+            jvmArg "-Dmixin.hotSwap=true"
+            jvmArg "-Dmixin.checks.interfaces=true"
+
+            workingDirectory project.file('run')
+
+            property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+            property 'forge.logging.console.level', 'debug'
+        }
+    }
 }
 
 repositories {
@@ -37,30 +55,23 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    testCompile "org.mockito:mockito-core:2.+"
+    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
+    testImplementation('junit:junit:4.13')
+    testImplementation("org.mockito:mockito-core:+")
 }
+
 
 processResources {
-    // this will ensure that this task is redone when the versions change.
-    inputs.property "modVersion", project.version
-    inputs.property "mcVersion", project.minecraft.version
+    inputs.property "version", project.version
+    inputs.property "mcversion", minecraft_version
 
-    // replace stuff in mcmod.info, nothing else
-    from(sourceSets.main.resources.srcDirs) {
-        include "mcmod.info"
-
-        // replace version and mcversion
-        expand "modVersion": project.version, "mcVersion": project.minecraft.version
+    filesMatching('mcmod.info') {
+        expand 'mod_id': modBaseName, 'mod_name': modBaseName, 'version': project.version,
+                'mcversion': minecraft_version, 'mod_description': mod_description,
+                'mod_author': modGroup
     }
-
-    // copy everything else, thats not the mcmod.info
-    from(sourceSets.main.resources.srcDirs) {
-        exclude "mcmod.info"
-    }
-
-    rename '(.+_at.cfg)', 'META-INF/$1'
 }
+
 
 jar {
     manifest {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,10 @@
 modGroup=Ladysnake
 modVersion=1.6.3b
 modBaseName=SpawnerControl
-#forgeVersion=1.11.2-13.20.1.2579
-#mcpVersion=stable_32
-forgeVersion=1.12.2-14.23.3.2669
 mcpVersion=snapshot_20180104
+mod_description=A minecraft mod to control mob spawner behaviour
+
+minecraft_version=1.12.2
+forge_version=14.23.5.2860
+mappings_channel=stable
+mappings_version=39-1.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 modGroup=Ladysnake
-modVersion=1.6.3b
+modVersion=1.7.0
 modBaseName=SpawnerControl
 mcpVersion=snapshot_20180104
 mod_description=A minecraft mod to control mob spawner behaviour

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 04 15:07:18 CET 2018
+#Sun Oct 06 12:09:16 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/src/main/java/ladysnake/spawnercontrol/SpawnerControl.java
+++ b/src/main/java/ladysnake/spawnercontrol/SpawnerControl.java
@@ -14,6 +14,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.capabilities.CapabilityManager;
@@ -57,12 +58,12 @@ public class SpawnerControl {
         CapabilityManager.INSTANCE.register(IControllableSpawner.class, new CapabilityControllableSpawner.Storage(), CapabilityControllableSpawner.DefaultControllableSpawner::new);
         // No need to register a tile entity that's not used anywhere
         if (MSCConfig.customSpawners.length > 0)
-            GameRegistry.registerTileEntity(TileEntityControlledSpawner.class, "spawnercontrol:controlled_spawner");
+            GameRegistry.registerTileEntity(TileEntityControlledSpawner.class,new ResourceLocation("spawnercontrol:controlled_spawner"));
         if (MSCConfig.makeCreativeTab) {
             creativeTab = new CreativeTabs(MOD_ID) {
                 @Nonnull
                 @Override
-                public ItemStack getTabIconItem() {
+                public ItemStack createIcon() {
                     return new ItemStack(Blocks.MOB_SPAWNER);
                 }
             };

--- a/src/main/java/ladysnake/spawnercontrol/SpawnerEventHandler.java
+++ b/src/main/java/ladysnake/spawnercontrol/SpawnerEventHandler.java
@@ -9,6 +9,7 @@ import ladysnake.spawnercontrol.controlledspawner.IControllableSpawner;
 import ladysnake.spawnercontrol.controlledspawner.TileEntityControlledSpawner;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockMobSpawner;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
@@ -142,9 +143,11 @@ public class SpawnerEventHandler {
             }
             // increments spawn counts and prevents spawns if over the limit
             if (canSpawn) {
-                if (handler.canSpawn()) {
+                if (handler.canSpawn() && !handler.tooManyAlive()) {
                     if (!handler.getConfig().incrementOnMobDeath)
                         handler.incrementSpawnedMobsCount();
+
+                    handler.incrementAliveMobsCount();
 
                     NBTTagCompound compound = new NBTTagCompound();
                     World spawnerWorld = spawner.getSpawnerWorld();
@@ -196,6 +199,7 @@ public class SpawnerEventHandler {
                 IControllableSpawner handler = CapabilityControllableSpawner.getHandler(spawner);
                 if (handler.getConfig().incrementOnMobDeath)
                     handler.incrementSpawnedMobsCount();
+                handler.decrementAliveMobsCount();
             }
         }
     }

--- a/src/main/java/ladysnake/spawnercontrol/SpawnerEventHandler.java
+++ b/src/main/java/ladysnake/spawnercontrol/SpawnerEventHandler.java
@@ -233,7 +233,7 @@ public class SpawnerEventHandler {
                             ItemStack stack = drop.getItem();
                             for (String s : entry.removedItems) {
                                 String[] split = s.split(":");
-                                if (stack.getUnlocalizedName().equals(split[0] + ":" + split[1])
+                                if (stack.getTranslationKey().equals(split[0] + ":" + split[1])
                                         && (split.length < 3 || stack.getMetadata() == Integer.parseInt(split[2]))) {
                                     drops.remove(drop);
                                 }

--- a/src/main/java/ladysnake/spawnercontrol/config/SpawnerConfig.java
+++ b/src/main/java/ladysnake/spawnercontrol/config/SpawnerConfig.java
@@ -75,7 +75,7 @@ public class SpawnerConfig {
             List<String> addedItems = Arrays.asList(defaultValues.addedItems);
             for (String s : xpMultipliers) {
                 String[] split = s.split(":");
-                if (split[0].equals(rl.getResourcePath()) && split[1].equals(rl.getResourceDomain())) {
+                if (split[0].equals(rl.getPath()) && split[1].equals(rl.getNamespace())) {
                     try {
                         xpMultiplier = Float.parseFloat(split[2]);
                         flatXpIncrease = split.length > 3 ? Integer.parseInt(split[3]) : defaultValues.flatXpIncrease;
@@ -88,7 +88,7 @@ public class SpawnerConfig {
             for (String s : itemDropRemovals) {
                 String[] split = s.split(",");
                 String[] mobSplit = split[0].split(":");
-                if (mobSplit[0].equals(rl.getResourcePath()) && mobSplit[1].equals(rl.getResourceDomain())) {
+                if (mobSplit[0].equals(rl.getPath()) && mobSplit[1].equals(rl.getNamespace())) {
                     try {
                         removedItems = Arrays.asList(split);
                         removedItems.remove(0);
@@ -101,7 +101,7 @@ public class SpawnerConfig {
             }
             for (String s : itemDropAdditions) {
                 String[] split = s.split(":");
-                if (split[0].equals(rl.getResourcePath()) && split[1].equals(rl.getResourceDomain())) {
+                if (split[0].equals(rl.getPath()) && split[1].equals(rl.getNamespace())) {
                     try {
                         addedItems = Arrays.asList(split);
                         addedItems.remove(0);

--- a/src/main/java/ladysnake/spawnercontrol/config/SpawnerConfig.java
+++ b/src/main/java/ladysnake/spawnercontrol/config/SpawnerConfig.java
@@ -21,6 +21,12 @@ public class SpawnerConfig {
     @Config.Comment("When a spawner has spawned this number of mobs over this lifetime, it will get broken automatically")
     public int mobThreshold = 100;
 
+    @Config.Comment("While this number of mobs from this spawner are alive, it will pause spawning")
+    public int aliveMobThreshold = 100;
+
+    @Config.Comment("Pause spawning if too many spawned mobs are alive")
+    public boolean pauseIfTooManyAlive = false;
+
     @Config.Comment("If set to true, spawners will count mobs when they are killed rather than when they are spawned")
     public boolean incrementOnMobDeath = false;
 

--- a/src/main/java/ladysnake/spawnercontrol/config/SpawnerConfigHolder.java
+++ b/src/main/java/ladysnake/spawnercontrol/config/SpawnerConfigHolder.java
@@ -42,7 +42,7 @@ public class SpawnerConfigHolder {
     public Block createBlock() {
         return new BlockControlledSpawner(getConfigObject())
                 .setRegistryName(this.registryName)
-                .setUnlocalizedName("msc." + name)
+                .setTranslationKey("msc." + name)
                 .setCreativeTab(SpawnerControl.creativeTab);
     }
 

--- a/src/main/java/ladysnake/spawnercontrol/controlledspawner/CapabilityControllableSpawner.java
+++ b/src/main/java/ladysnake/spawnercontrol/controlledspawner/CapabilityControllableSpawner.java
@@ -31,6 +31,7 @@ public class CapabilityControllableSpawner {
     public static class DefaultControllableSpawner implements IControllableSpawner {
         private final TileEntityMobSpawner spawner;
         private int spawnedMobsCount;
+        private int aliveMobsCount;
 
         public DefaultControllableSpawner() {
             this(null);
@@ -46,6 +47,11 @@ public class CapabilityControllableSpawner {
         }
 
         @Override
+        public void setAliveMobsCount(int mobCount) {
+            this.aliveMobsCount = mobCount;
+        }
+
+        @Override
         public boolean incrementSpawnedMobsCount() {
             SpawnerConfig cfg = getConfig();
             if(++this.spawnedMobsCount >= cfg.mobThreshold) {
@@ -55,6 +61,16 @@ public class CapabilityControllableSpawner {
             }
             this.adjustDelayAfterSpawn(spawner.getSpawnerBaseLogic(), cfg.spawnRateModifier);
             return false;
+        }
+
+        @Override
+        public void incrementAliveMobsCount() {
+            ++aliveMobsCount;
+        }
+
+        @Override
+        public void decrementAliveMobsCount() {
+            --aliveMobsCount;
         }
 
         /**
@@ -82,8 +98,21 @@ public class CapabilityControllableSpawner {
         }
 
         @Override
+        public int getAliveMobsCount() {
+            return aliveMobsCount;
+        }
+
+        @Override
         public boolean canSpawn() {
             return this.spawnedMobsCount < getConfig().mobThreshold;
+        }
+
+        @Override
+        public boolean tooManyAlive() {
+            if(getConfig().pauseIfTooManyAlive)
+                return this.aliveMobsCount >= getConfig().aliveMobThreshold;
+            else
+                return false;
         }
 
         @Nonnull
@@ -129,6 +158,7 @@ public class CapabilityControllableSpawner {
         public NBTBase writeNBT(Capability<IControllableSpawner> capability, IControllableSpawner instance, EnumFacing side) {
             NBTTagCompound nbt = new NBTTagCompound();
             nbt.setInteger("SpawnedMobsCount", instance.getSpawnedMobsCount());
+            nbt.setInteger("AliveMobsCount", instance.getAliveMobsCount());
             return nbt;
         }
 
@@ -136,6 +166,7 @@ public class CapabilityControllableSpawner {
         public void readNBT(Capability<IControllableSpawner> capability, IControllableSpawner instance, EnumFacing side, NBTBase nbt) {
             if (nbt instanceof NBTTagCompound) {
                 instance.setSpawnedMobsCount(((NBTTagCompound) nbt).getInteger("SpawnedMobsCount"));
+                instance.setAliveMobsCount(((NBTTagCompound) nbt).getInteger("AliveMobsCount"));
             }
         }
     }

--- a/src/main/java/ladysnake/spawnercontrol/controlledspawner/CapabilityControllableSpawner.java
+++ b/src/main/java/ladysnake/spawnercontrol/controlledspawner/CapabilityControllableSpawner.java
@@ -12,6 +12,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.util.Constants;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -60,8 +61,19 @@ public class CapabilityControllableSpawner {
          * Should be called after every spawn to tweak the cooldown according to the config
          */
         protected void adjustDelayAfterSpawn(MobSpawnerBaseLogic spawnerBaseLogic, double spawnRateModifier) {
-            spawnerBaseLogic.minSpawnDelay *= spawnRateModifier;
-            spawnerBaseLogic.maxSpawnDelay *= spawnRateModifier;
+            NBTTagCompound tags = new NBTTagCompound();
+            spawnerBaseLogic.writeToNBT(tags);
+            int minSpawnDelay = tags.getInteger("MinSpawnDelay");
+            int maxSpawnDelay = tags.getInteger("MaxSpawnDelay");
+
+            minSpawnDelay = (int) (minSpawnDelay*spawnRateModifier);
+            maxSpawnDelay = (int) (maxSpawnDelay*spawnRateModifier);
+
+            tags.setInteger("MinSpawnDelay",minSpawnDelay);
+            tags.setInteger("MaxSpawnDelay",maxSpawnDelay);
+
+            spawnerBaseLogic.readFromNBT(tags);
+
         }
 
         @Override

--- a/src/main/java/ladysnake/spawnercontrol/controlledspawner/IControllableSpawner.java
+++ b/src/main/java/ladysnake/spawnercontrol/controlledspawner/IControllableSpawner.java
@@ -19,6 +19,12 @@ public interface IControllableSpawner {
     int getSpawnedMobsCount();
 
     boolean canSpawn();
+    boolean tooManyAlive();
 
     SpawnerConfig getConfig();
+
+    void incrementAliveMobsCount();
+    void decrementAliveMobsCount();
+    void setAliveMobsCount(int var1);
+    int getAliveMobsCount();
 }

--- a/src/main/java/ladysnake/spawnercontrol/controlledspawner/ItemBlockControlSpawner.java
+++ b/src/main/java/ladysnake/spawnercontrol/controlledspawner/ItemBlockControlSpawner.java
@@ -21,7 +21,7 @@ public class ItemBlockControlSpawner extends ItemBlock {
     @Override
     public String getItemStackDisplayName(@Nonnull ItemStack stack) {
         // in case someone makes a custom lang file to translate their spawner names
-        if (I18n.canTranslate(getUnlocalizedName(stack) + ".name"))
+        if (I18n.canTranslate(getTranslationKey(stack) + ".name"))
             return super.getItemStackDisplayName(stack);
         // return a default readable value
         return I18n.translateToLocalFormatted(DEFAULT_LANG_KEY, name).trim();

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,8 +3,8 @@
     "modid": "spawnercontrol",
     "name": "SpawnerControl",
     "description": "A mod to customise spawners behaviour",
-    "version": "${modVersion}",
-    "mcversion": "${mcVersion}",
+    "version": "${version}",
+    "mcversion": "${mcversion}",
     "url": "",
     "updateUrl": "",
     "authorList": [


### PR DESCRIPTION
Spawners set to break on x amounts of deaths (not spawns) can be abused by just letting mobs spawn over time and moving them out of vanilla check range (just falling 6 blocks down). 

To prevent this, added an optional cap to count how many mobs were spawned which are still alive. 

Doesn't decrement the counter on despawns, but this can be fixed with a mixin into Entity.setDead() via other mod